### PR TITLE
PDI-10432 - pentaho-cassandra-plugin-1.0.0.zip has a spurious .gitignore in the .zip

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -9,7 +9,10 @@
 ============================================================================-->
 <project name="Pentaho Cassandra Plugin" basedir="." default="dist"
 	xmlns:ivy="antlib:org.apache.ivy.ant" >
-	
+
+	<!-- For ant version below 1.8.2 -->
+	<defaultexcludes add="**/.gitignore"/>
+
 	<description>
 	  This build file is used to create the Pentaho Cassandra project
 		and works with the subfloor.xml file.


### PR DESCRIPTION
Add defaultexcludes for ant < 1.8.2 which prevents package-res/.gitignore from being copied to staging dir.
