### PR TITLE
PDI-7516 Specifying large limit in Cassandra input step causes timeout errors

### DIFF
--- a/src/org/pentaho/cassandra/CassandraUtils.java
+++ b/src/org/pentaho/cassandra/CassandraUtils.java
@@ -65,6 +65,7 @@ public class CassandraUtils {
 
   public static class ConnectionOptions {
     public static final String SOCKET_TIMEOUT = "socketTimeout"; //$NON-NLS-1$
+    public static final String MAX_LENGTH = "maxLength"; //$NON-NLS-1$
   }
 
   public static class CQLOptions {

--- a/src/org/pentaho/cassandra/legacy/CassandraConnection.java
+++ b/src/org/pentaho/cassandra/legacy/CassandraConnection.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.cassandra.legacy;
 
@@ -40,9 +40,8 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.i18n.BaseMessages;
 
 /**
- * Class for establishing a connection with Cassandra. Encapsulates the
- * transport and Cassandra client object.
- * 
+ * Class for establishing a connection with Cassandra. Encapsulates the transport and Cassandra client object.
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  * @version $Revision; $
  */
@@ -60,6 +59,7 @@ public class CassandraConnection implements Connection {
   protected String m_username = ""; //$NON-NLS-1$
   protected String m_password = ""; //$NON-NLS-1$
   protected int m_timeout = -1;
+  protected int m_maxlength = -1;
 
   protected Map<String, String> m_options;
 
@@ -69,54 +69,65 @@ public class CassandraConnection implements Connection {
 
   /**
    * Construct an CassandaraConnection with no authentication.
-   * 
+   *
    * @param host the host to connect to
    * @param port the port to use
    * @throws Exception if the connection fails
    */
-  public CassandraConnection(String host, int port) throws Exception {
-    this(host, port, null, null, -1);
+  public CassandraConnection( String host, int port ) throws Exception {
+    this( host, port, null, null, -1 );
   }
 
   /**
-   * Construct a CassandraConnection with no authentication and the supplied
-   * socket timeout (milliseconds).
-   * 
-   * @param host the host to connect to
-   * @param port the port to use
+   * Construct a CassandraConnection with no authentication and the supplied socket timeout (milliseconds).
+   *
+   * @param host    the host to connect to
+   * @param port    the port to use
    * @param timeout the socket timeout to use in milliseconds
    * @throws Exception if the connection fails
    */
-  public CassandraConnection(String host, int port, int timeout)
-      throws Exception {
-    this(host, port, null, null, timeout);
+  public CassandraConnection( String host, int port, int timeout )
+    throws Exception {
+    this( host, port, null, null, timeout );
   }
 
   /**
    * Construct an CassandaraConnection with optional authentication.
-   * 
-   * @param host the host to connect to
-   * @param port the port to use
-   * @param username the username to authenticate with (may be null for no
-   *          authentication)
-   * @param password the password to authenticate with (may be null for no
-   *          authentication)
+   *
+   * @param host     the host to connect to
+   * @param port     the port to use
+   * @param username the username to authenticate with (may be null for no authentication)
+   * @param password the password to authenticate with (may be null for no authentication)
    * @throws Exception if the connection fails
    */
-  public CassandraConnection(String host, int port, String username,
-      String password, int timeout) throws Exception {
+  public CassandraConnection( String host, int port, String username,
+                              String password, int timeout ) throws Exception {
+    this( host, port, username, password, timeout, -1 );
+  }
+
+  /**
+   * Construct an CassandaraConnection with optional authentication.
+   *
+   * @param host     the host to connect to
+   * @param port     the port to use
+   * @param username the username to authenticate with (may be null for no authentication)
+   * @param password the password to authenticate with (may be null for no authentication)
+   * @throws Exception if the connection fails
+   */
+  public CassandraConnection( String host, int port, String username,
+                              String password, int timeout, int maxlength ) throws Exception {
     m_host = host;
     m_port = port;
     m_username = username;
     m_password = password;
     m_timeout = timeout;
-
+    m_maxlength = maxlength;
     openConnection();
   }
 
   /**
    * Get the encapsulated Cassandra.Client object
-   * 
+   *
    * @return the encapsulated Cassandra.Client object
    */
   public Cassandra.Client getClient() {
@@ -125,38 +136,38 @@ public class CassandraConnection implements Connection {
 
   /**
    * Get a keyspace definition for the set keyspace
-   * 
+   *
    * @return a keyspace definition
    * @throws Exception if a problem occurs
    */
   public KsDef describeKeyspace() throws Exception {
-    if (m_keyspaceName == null || m_keyspaceName.length() == 0) {
-      throw new Exception(BaseMessages.getString(PKG,
-          "CassandraConnection.Error.NoKeyspaceHasBeenSet")); //$NON-NLS-1$
+    if ( m_keyspaceName == null || m_keyspaceName.length() == 0 ) {
+      throw new Exception( BaseMessages.getString( PKG,
+        "CassandraConnection.Error.NoKeyspaceHasBeenSet" ) ); //$NON-NLS-1$
     }
 
-    return m_client.describe_keyspace(m_keyspaceName);
+    return m_client.describe_keyspace( m_keyspaceName );
   }
 
   public void close() {
     try {
       closeConnection();
-    } catch (Exception ex) {
+    } catch ( Exception ex ) {
       // swallow this exception since it will never get thrown
     }
   }
 
   private void checkOpen() throws Exception {
-    if (m_transport == null && m_client == null) {
+    if ( m_transport == null && m_client == null ) {
       openConnection();
 
-      if (m_options != null) {
-        for (Map.Entry<String, String> e : m_options.entrySet()) {
-          if (e.getKey().equals(CassandraUtils.CQLOptions.CQLVERSION_OPTION)) {
-            if (e.getValue().equals(CassandraUtils.CQLOptions.CQL3_STRING)) {
+      if ( m_options != null ) {
+        for ( Map.Entry<String, String> e : m_options.entrySet() ) {
+          if ( e.getKey().equals( CassandraUtils.CQLOptions.CQLVERSION_OPTION ) ) {
+            if ( e.getValue().equals( CassandraUtils.CQLOptions.CQL3_STRING ) ) {
               // System.out.println("Connection setting CQL version to "
               // + e.getValue());
-              m_client.set_cql_version(e.getValue());
+              m_client.set_cql_version( e.getValue() );
             }
           }
         }
@@ -166,60 +177,71 @@ public class CassandraConnection implements Connection {
 
   /**
    * Set the Cassandra keyspace (database) to use.
-   * 
+   *
    * @param keySpace the name of the keyspace to use
    * @throws Exception if the keyspace doesn't exist
    */
-  public void setKeyspace(String keySpace) throws Exception {
+  public void setKeyspace( String keySpace ) throws Exception {
     checkOpen();
 
-    m_client.set_keyspace(keySpace);
+    m_client.set_keyspace( keySpace );
     m_keyspaceName = keySpace;
   }
 
-  public void setHosts(String hosts) {
-    String[] parts = hosts.split(","); //$NON-NLS-1$
+  public void setHosts( String hosts ) {
+    String[] parts = hosts.split( "," ); //$NON-NLS-1$
 
     // we use only one host
-    if (parts.length > 0) {
-      String[] parts2 = parts[0].split(":"); //$NON-NLS-1$
-      if (parts2.length > 0) {
-        m_host = parts2[0].trim();
+    if ( parts.length > 0 ) {
+      String[] parts2 = parts[ 0 ].split( ":" ); //$NON-NLS-1$
+      if ( parts2.length > 0 ) {
+        m_host = parts2[ 0 ].trim();
       }
 
-      if (parts2.length > 1) {
+      if ( parts2.length > 1 ) {
         try {
-          m_port = Integer.parseInt(parts2[1].trim());
-        } catch (NumberFormatException ex) {
+          m_port = Integer.parseInt( parts2[ 1 ].trim() );
+        } catch ( NumberFormatException ex ) {
+          //ignored
         }
       }
     }
   }
 
-  public void setDefaultPort(int port) {
+  public void setDefaultPort( int port ) {
     m_port = port;
   }
 
-  public void setUsername(String username) {
+  public void setUsername( String username ) {
     m_username = username;
   }
 
-  public void setPassword(String password) {
+  public void setPassword( String password ) {
     m_password = password;
   }
 
-  public void setAdditionalOptions(Map<String, String> opts) {
+  public void setAdditionalOptions( Map<String, String> opts ) {
     m_options = opts;
 
-    if (m_options != null && m_options.size() > 0) {
-      for (Map.Entry<String, String> entry : m_options.entrySet()) {
-        if (entry.getKey().equalsIgnoreCase(
-            CassandraUtils.ConnectionOptions.SOCKET_TIMEOUT)) {
+    if ( m_options != null && m_options.size() > 0 ) {
+      for ( Map.Entry<String, String> entry : m_options.entrySet() ) {
+        if ( entry.getKey().equalsIgnoreCase(
+          CassandraUtils.ConnectionOptions.SOCKET_TIMEOUT ) ) {
           String v = entry.getValue().trim();
 
           try {
-            m_timeout = Integer.parseInt(v);
-          } catch (NumberFormatException ex) {
+            m_timeout = Integer.parseInt( v );
+          } catch ( NumberFormatException ex ) {
+            //ignored
+          }
+        } else if ( entry.getKey().equalsIgnoreCase(
+          CassandraUtils.ConnectionOptions.MAX_LENGTH ) ) {
+          String v = entry.getValue().trim();
+
+          try {
+            m_maxlength = Integer.parseInt( v );
+          } catch ( NumberFormatException ex ) {
+            //ignored
           }
         }
       }
@@ -231,26 +253,30 @@ public class CassandraConnection implements Connection {
   }
 
   public void openConnection() throws Exception {
-    TSocket socket = new TSocket(m_host, m_port);
-    if (m_timeout > 0) {
-      socket.setTimeout(m_timeout);
+    TSocket socket = new TSocket( m_host, m_port );
+    if ( m_timeout > 0 ) {
+      socket.setTimeout( m_timeout );
+    }
+    if ( m_maxlength > 0 ) {
+      m_transport = new TFramedTransport( socket, m_maxlength );
+    } else {
+      m_transport = new TFramedTransport( socket );
     }
 
-    m_transport = new TFramedTransport(socket);
-    TProtocol protocol = new TBinaryProtocol(m_transport);
-    m_client = new Cassandra.Client(protocol);
+    TProtocol protocol = new TBinaryProtocol( m_transport );
+    m_client = new Cassandra.Client( protocol );
     m_transport.open();
 
-    if (!Const.isEmpty(m_username) && !Const.isEmpty(m_password)) {
+    if ( !Const.isEmpty( m_username ) && !Const.isEmpty( m_password ) ) {
       Map<String, String> creds = new HashMap<String, String>();
-      creds.put("username", m_username); //$NON-NLS-1$
-      creds.put("password", m_password); //$NON-NLS-1$
-      m_client.login(new AuthenticationRequest(creds));
+      creds.put( "username", m_username ); //$NON-NLS-1$
+      creds.put( "password", m_password ); //$NON-NLS-1$
+      m_client.login( new AuthenticationRequest( creds ) );
     }
   }
 
   public void closeConnection() throws Exception {
-    if (m_transport != null) {
+    if ( m_transport != null ) {
       m_transport.close();
       m_transport = null;
       m_client = null;
@@ -269,12 +295,12 @@ public class CassandraConnection implements Connection {
     return true;
   }
 
-  public Keyspace getKeyspace(String keyspacename) throws Exception {
+  public Keyspace getKeyspace( String keyspacename ) throws Exception {
 
     LegacyKeyspace ks = new LegacyKeyspace();
-    ks.setConnection(this);
-    ks.setOptions(m_options);
-    ks.setKeyspace(keyspacename);
+    ks.setConnection( this );
+    ks.setOptions( m_options );
+    ks.setKeyspace( keyspacename );
 
     return ks;
   }

--- a/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInput.java
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInput.java
@@ -121,6 +121,7 @@ public class CassandraInput extends BaseStep implements StepInterface {
         String hostS = environmentSubstitute( m_meta.getCassandraHost() );
         String portS = environmentSubstitute( m_meta.getCassandraPort() );
         String timeoutS = environmentSubstitute( m_meta.getSocketTimeout() );
+        String maxLength = environmentSubstitute( m_meta.getMaxLength() );
         String userS = m_meta.getUsername();
         String passS = m_meta.getPassword();
         if ( !Const.isEmpty( userS ) && !Const.isEmpty( passS ) ) {
@@ -140,6 +141,10 @@ public class CassandraInput extends BaseStep implements StepInterface {
 
         if ( !Const.isEmpty( timeoutS ) ) {
           opts.put( CassandraUtils.ConnectionOptions.SOCKET_TIMEOUT, timeoutS );
+        }
+
+        if ( !Const.isEmpty( maxLength ) ) {
+          opts.put( CassandraUtils.ConnectionOptions.MAX_LENGTH, maxLength );
         }
 
         if ( m_meta.getUseCQL3() ) {

--- a/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputDialog.java
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputDialog.java
@@ -76,7 +76,7 @@ import org.pentaho.di.ui.trans.steps.tableinput.SQLValuesHighlight;
 
 /**
  * Dialog class for the CassandraInput step
- * 
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  * @version $Revision$
  */
@@ -87,7 +87,9 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
   private final CassandraInputMeta m_currentMeta;
   private final CassandraInputMeta m_originalMeta;
 
-  /** various UI bits and pieces for the dialog */
+  /**
+   * various UI bits and pieces for the dialog
+   */
   private Label m_stepnameLabel;
   private Text m_stepnameText;
 
@@ -118,6 +120,9 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
 
   private Label m_timeoutLab;
   private TextVar m_timeoutText;
+
+  private Label m_maxLengthLab;
+  private TextVar m_maxLengthText;
 
   private Label m_positionLab;
 
@@ -263,13 +268,39 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
     fd.left = new FormAttachment( middle, 0 );
     m_timeoutText.setLayoutData( fd );
 
+    // max length line
+    m_maxLengthLab = new Label( shell, SWT.RIGHT );
+    props.setLook( m_maxLengthLab );
+    m_maxLengthLab
+      .setText( BaseMessages.getString( PKG, "CassandraInputDialog.TransportMaxLength.Label" ) ); //$NON-NLS-1$
+    fd = new FormData();
+    fd.left = new FormAttachment( 0, 0 );
+    fd.top = new FormAttachment( m_timeoutText, margin );
+    fd.right = new FormAttachment( middle, -margin );
+    m_maxLengthLab.setLayoutData( fd );
+
+    m_maxLengthText = new TextVar( transMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    props.setLook( m_maxLengthText );
+    m_maxLengthText.addModifyListener( new ModifyListener() {
+      @Override
+      public void modifyText( ModifyEvent e ) {
+        m_maxLengthText.setToolTipText( transMeta.environmentSubstitute( m_maxLengthText.getText() ) );
+      }
+    } );
+    m_maxLengthText.addModifyListener( lsMod );
+    fd = new FormData();
+    fd.right = new FormAttachment( 100, 0 );
+    fd.top = new FormAttachment( m_timeoutText, margin );
+    fd.left = new FormAttachment( middle, 0 );
+    m_maxLengthText.setLayoutData( fd );
+
     // username line
     m_userLab = new Label( shell, SWT.RIGHT );
     props.setLook( m_userLab );
     m_userLab.setText( BaseMessages.getString( PKG, "CassandraInputDialog.User.Label" ) ); //$NON-NLS-1$
     fd = new FormData();
     fd.left = new FormAttachment( 0, 0 );
-    fd.top = new FormAttachment( m_timeoutText, margin );
+    fd.top = new FormAttachment( m_maxLengthText, margin );
     fd.right = new FormAttachment( middle, -margin );
     m_userLab.setLayoutData( fd );
 
@@ -284,7 +315,7 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
     m_userText.addModifyListener( lsMod );
     fd = new FormData();
     fd.right = new FormAttachment( 100, 0 );
-    fd.top = new FormAttachment( m_timeoutText, margin );
+    fd.top = new FormAttachment( m_maxLengthText, margin );
     fd.left = new FormAttachment( middle, 0 );
     m_userText.setLayoutData( fd );
 
@@ -418,7 +449,8 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
     // compression check box
     m_compressionLab = new Label( shell, SWT.RIGHT );
     props.setLook( m_compressionLab );
-    m_compressionLab.setText( BaseMessages.getString( PKG, "CassandraInputDialog.UseCompression.Label" ) ); //$NON-NLS-1$
+    m_compressionLab
+      .setText( BaseMessages.getString( PKG, "CassandraInputDialog.UseCompression.Label" ) ); //$NON-NLS-1$
     fd = new FormData();
     fd.left = new FormAttachment( 0, 0 );
     fd.top = new FormAttachment( m_useThriftCheck, margin );
@@ -442,7 +474,8 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
     // execute for each row
     Label executeForEachLab = new Label( shell, SWT.RIGHT );
     props.setLook( executeForEachLab );
-    executeForEachLab.setText( BaseMessages.getString( PKG, "CassandraInputDialog.ExecuteForEachRow.Label" ) ); //$NON-NLS-1$
+    executeForEachLab
+      .setText( BaseMessages.getString( PKG, "CassandraInputDialog.ExecuteForEachRow.Label" ) ); //$NON-NLS-1$
     fd = new FormData();
     fd.right = new FormAttachment( middle, -margin );
     fd.left = new FormAttachment( 0, 0 );
@@ -503,7 +536,8 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
     m_cqlLab.setLayoutData( fd );
 
     m_cqlText =
-        new StyledTextComp( transMeta, shell, SWT.MULTI | SWT.LEFT | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL, "" ); //$NON-NLS-1$
+      new StyledTextComp( transMeta, shell, SWT.MULTI | SWT.LEFT | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL,
+        "" ); //$NON-NLS-1$
     props.setLook( m_cqlText, props.WIDGET_STYLE_FIXED );
     m_cqlText.addModifyListener( lsMod );
     fd = new FormData();
@@ -676,7 +710,8 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
       m_outputTuplesBut.setSelection( false );
       m_outputTuplesBut.setEnabled( false );
 
-      m_outputTuplesLab.setToolTipText( BaseMessages.getString( PKG, "CassandraInputDialog.OutputTuples.TipText" ) ); //$NON-NLS-1$
+      m_outputTuplesLab
+        .setToolTipText( BaseMessages.getString( PKG, "CassandraInputDialog.OutputTuples.TipText" ) ); //$NON-NLS-1$
     } else {
       m_outputTuplesBut.setEnabled( true );
       m_outputTuplesLab.setToolTipText( "" ); //$NON-NLS-1$
@@ -687,6 +722,7 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
     meta.setCassandraHost( m_hostText.getText() );
     meta.setCassandraPort( m_portText.getText() );
     meta.setSocketTimeout( m_timeoutText.getText() );
+    meta.setMaxLength( m_maxLengthText.getText() );
     meta.setUsername( m_userText.getText() );
     meta.setPassword( m_passText.getText() );
     meta.setCassandraKeyspace( m_keyspaceText.getText() );
@@ -734,6 +770,10 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
       m_timeoutText.setText( m_currentMeta.getSocketTimeout() );
     }
 
+    if ( !Const.isEmpty( m_currentMeta.getMaxLength() ) ) {
+      m_maxLengthText.setText( m_currentMeta.getMaxLength() );
+    }
+
     if ( !Const.isEmpty( m_currentMeta.getUsername() ) ) {
       m_userText.setText( m_currentMeta.getUsername() );
     }
@@ -772,7 +812,8 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
       colnr++;
     }
     m_positionLab
-        .setText( BaseMessages.getString( PKG, "CassandraInputDialog.Position.Label", "" + linenr, "" + colnr ) ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+      .setText( BaseMessages.getString( PKG, "CassandraInputDialog.Position.Label", "" + linenr,
+        "" + colnr ) ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
   }
 
   private void checkPasswordVisible() {
@@ -793,8 +834,8 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
 
     if ( notOk ) {
       ShowMessageDialog smd =
-          new ShowMessageDialog( shell, SWT.ICON_WARNING | SWT.OK, title, BaseMessages.getString( PKG,
-              "CassandraInputDialog.Warning.Message.CassandraQueryContainsUnresolvedVarsFieldSubs" ) ); //$NON-NLS-1$
+        new ShowMessageDialog( shell, SWT.ICON_WARNING | SWT.OK, title, BaseMessages.getString( PKG,
+          "CassandraInputDialog.Warning.Message.CassandraQueryContainsUnresolvedVarsFieldSubs" ) ); //$NON-NLS-1$
       smd.open();
     }
 
@@ -811,23 +852,24 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
     oneMeta.setExecuteForEachIncomingRow( false );
 
     if ( !checkForUnresolved( oneMeta, BaseMessages.getString( PKG,
-        "CassandraInputDialog.Warning.Message.CassandraQueryContainsUnresolvedVarsFieldSubs.PreviewTitle" ) ) ) { //$NON-NLS-1$
+      "CassandraInputDialog.Warning.Message.CassandraQueryContainsUnresolvedVarsFieldSubs.PreviewTitle" ) ) ) {
+      //$NON-NLS-1$
       return;
     }
 
     TransMeta previewMeta =
-        TransPreviewFactory.generatePreviewTransformation( transMeta, oneMeta, m_stepnameText.getText() );
+      TransPreviewFactory.generatePreviewTransformation( transMeta, oneMeta, m_stepnameText.getText() );
 
     EnterNumberDialog numberDialog =
-        new EnterNumberDialog( shell, props.getDefaultPreviewSize(), BaseMessages.getString( PKG,
-            "CassandraInputDialog.PreviewSize.DialogTitle" ), //$NON-NLS-1$
-            BaseMessages.getString( PKG, "CassandraInputDialog.PreviewSize.DialogMessage" ) ); //$NON-NLS-1$
+      new EnterNumberDialog( shell, props.getDefaultPreviewSize(), BaseMessages.getString( PKG,
+        "CassandraInputDialog.PreviewSize.DialogTitle" ), //$NON-NLS-1$
+        BaseMessages.getString( PKG, "CassandraInputDialog.PreviewSize.DialogMessage" ) ); //$NON-NLS-1$
 
     int previewSize = numberDialog.open();
     if ( previewSize > 0 ) {
       TransPreviewProgressDialog progressDialog =
-          new TransPreviewProgressDialog( shell, previewMeta, new String[] { m_stepnameText.getText() },
-              new int[] { previewSize } );
+        new TransPreviewProgressDialog( shell, previewMeta, new String[] { m_stepnameText.getText() },
+          new int[] { previewSize } );
       progressDialog.open();
 
       Trans trans = progressDialog.getTrans();
@@ -836,17 +878,17 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
       if ( !progressDialog.isCancelled() ) {
         if ( trans.getResult() != null && trans.getResult().getNrErrors() > 0 ) {
           EnterTextDialog etd =
-              new EnterTextDialog( shell, BaseMessages.getString( PKG, "System.Dialog.PreviewError.Title" ), //$NON-NLS-1$
-                  BaseMessages.getString( PKG, "System.Dialog.PreviewError.Message" ), //$NON-NLS-1$
-                  loggingText, true );
+            new EnterTextDialog( shell, BaseMessages.getString( PKG, "System.Dialog.PreviewError.Title" ), //$NON-NLS-1$
+              BaseMessages.getString( PKG, "System.Dialog.PreviewError.Message" ), //$NON-NLS-1$
+              loggingText, true );
           etd.setReadOnly();
           etd.open();
         }
       }
       PreviewRowsDialog prd =
-          new PreviewRowsDialog( shell, transMeta, SWT.NONE, m_stepnameText.getText(), progressDialog
-              .getPreviewRowsMeta( m_stepnameText.getText() ),
-              progressDialog.getPreviewRows( m_stepnameText.getText() ), loggingText );
+        new PreviewRowsDialog( shell, transMeta, SWT.NONE, m_stepnameText.getText(), progressDialog
+          .getPreviewRowsMeta( m_stepnameText.getText() ),
+          progressDialog.getPreviewRows( m_stepnameText.getText() ), loggingText );
       prd.open();
     }
   }
@@ -874,8 +916,8 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
         }
 
         conn =
-            CassandraUtils.getCassandraConnection( hostS, Integer.parseInt( portS ), userS, passS,
-                ConnectionFactory.Driver.LEGACY_THRIFT, opts );
+          CassandraUtils.getCassandraConnection( hostS, Integer.parseInt( portS ), userS, passS,
+            ConnectionFactory.Driver.LEGACY_THRIFT, opts );
 
         conn.setHosts( hostS );
         conn.setDefaultPort( Integer.parseInt( portS ) );
@@ -883,12 +925,13 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
         conn.setPassword( passS );
         kSpace = conn.getKeyspace( keyspaceS );
       } catch ( InvalidRequestException ire ) {
-        logError( BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
+        logError(
+          BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
             + ":\n\n" + ire.why, ire ); //$NON-NLS-1$
         new ErrorDialog( shell, BaseMessages.getString( PKG,
-            "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Title" ), //$NON-NLS-1$
-            BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
-                + ":\n\n" + ire.why, ire ); //$NON-NLS-1$
+          "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Title" ), //$NON-NLS-1$
+          BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
+            + ":\n\n" + ire.why, ire ); //$NON-NLS-1$
         return;
       }
 
@@ -899,25 +942,29 @@ public class CassandraInputDialog extends BaseStepDialog implements StepDialogIn
 
       if ( !kSpace.columnFamilyExists( colFam ) ) {
         throw new Exception(
-            BaseMessages
-                .getString(
-                    PKG,
-                    "CassandraInput.Error.NonExistentColumnFamily", m_useCQL3Check.getSelection() ? CassandraUtils.removeQuotes( colFam ) : colFam, keyspaceS ) ); //$NON-NLS-1$
+          BaseMessages
+            .getString(
+              PKG,
+              "CassandraInput.Error.NonExistentColumnFamily",
+              m_useCQL3Check.getSelection() ? CassandraUtils.removeQuotes( colFam ) : colFam,
+              keyspaceS ) ); //$NON-NLS-1$
       }
 
       CassandraColumnMetaData cassMeta = (CassandraColumnMetaData) kSpace.getColumnFamilyMetaData( colFam );
 
       String schemaDescription = cassMeta.getSchemaDescription();
       ShowMessageDialog smd =
-          new ShowMessageDialog( shell, SWT.ICON_INFORMATION | SWT.OK, "Schema info", schemaDescription, true ); //$NON-NLS-1$
+        new ShowMessageDialog( shell, SWT.ICON_INFORMATION | SWT.OK, "Schema info", schemaDescription,
+          true ); //$NON-NLS-1$
       smd.open();
     } catch ( Exception e1 ) {
-      logError( BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
+      logError(
+        BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
           + ":\n\n" + e1.getMessage(), e1 ); //$NON-NLS-1$
       new ErrorDialog( shell,
-          BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Title" ), //$NON-NLS-1$
-          BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
-              + ":\n\n" + e1.getMessage(), e1 ); //$NON-NLS-1$
+        BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Title" ), //$NON-NLS-1$
+        BaseMessages.getString( PKG, "CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message" ) //$NON-NLS-1$
+          + ":\n\n" + e1.getMessage(), e1 ); //$NON-NLS-1$
     } finally {
       if ( conn != null ) {
         try {

--- a/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputMeta.java
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputMeta.java
@@ -62,53 +62,80 @@ import org.w3c.dom.Node;
 
 /**
  * Class providing an input step for reading data from an Cassandra column family (table).
- * 
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  * @version $Revision$
  */
 @Step( id = "CassandraInput", image = "Cassandra.png", name = "Cassandra Input",
-    description = "Reads data from a Cassandra table", categoryDescription = "Big Data" )
+  description = "Reads data from a Cassandra table", categoryDescription = "Big Data" )
 public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   protected static final Class<?> PKG = CassandraInputMeta.class;
 
-  /** The host to contact */
+  /**
+   * The host to contact
+   */
   protected String m_cassandraHost = "localhost"; //$NON-NLS-1$
 
-  /** The port that cassandra is listening on */
+  /**
+   * The port that cassandra is listening on
+   */
   protected String m_cassandraPort = "9160"; //$NON-NLS-1$
 
-  /** Username for authentication */
+  /**
+   * Username for authentication
+   */
   protected String m_username;
 
-  /** Password for authentication */
+  /**
+   * Password for authentication
+   */
   protected String m_password;
 
-  /** The keyspace (database) to use */
+  /**
+   * The keyspace (database) to use
+   */
   protected String m_cassandraKeyspace;
 
-  /** Whether to use GZIP compression of CQL queries */
+  /**
+   * Whether to use GZIP compression of CQL queries
+   */
   protected boolean m_useCompression;
 
-  /** The select query to execute */
+  /**
+   * The select query to execute
+   */
   protected String m_cqlSelectQuery = "SELECT <fields> FROM <column family> WHERE <condition>;"; //$NON-NLS-1$
 
-  /** Output in tuple mode? */
+  /**
+   * Output in tuple mode?
+   */
   protected boolean m_outputKeyValueTimestampTuples;
 
-  /** Use thrift IO for tuple mode? */
+  /**
+   * Use thrift IO for tuple mode?
+   */
   protected boolean m_useThriftIO = false;
 
-  /** Whether to use CQL version 3 */
+  /**
+   * Whether to use CQL version 3
+   */
   protected boolean m_useCQL3 = false;
 
-  /** Whether to execute the query for each incoming row */
+  /**
+   * Whether to execute the query for each incoming row
+   */
   protected boolean m_executeForEachIncomingRow;
 
   /**
    * Timeout (milliseconds) to use for socket connections - blank means use cluster default
    */
   protected String m_socketTimeout = ""; //$NON-NLS-1$
+
+  /**
+   * Max size of the object can be transported - blank means use default (16384000)
+   */
+  protected String m_maxLength = ""; //$NON-NLS-1$
 
   // set based on parsed CQL
   /**
@@ -123,9 +150,9 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
   // these are set based on the parsed CQL when executing tuple mode using
   // thrift
   protected int m_rowLimit = -1; // no limit - otherwise we look for LIMIT in
-                                 // CQL
+  // CQL
   protected int m_colLimit = -1; // no limit - otherwise we look for FIRST N in
-                                 // CQL
+  // CQL
 
   // maximum number of rows or columns to pull over at one time via thrift
   protected int m_rowBatchSize = 100;
@@ -133,10 +160,27 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
   protected List<String> m_specificCols;
 
   /**
+   * Get the max length (bytes) to use for transport
+   *
+   * @return the max transport length to use in bytes
+   */
+  public String getMaxLength() {
+    return m_maxLength;
+  }
+
+  /**
+   * Set the max length (bytes) to use for transport
+   *
+   * @param maxLength the max transport length to use in bytes
+   */
+  public void setMaxLength( String maxLength ) {
+    this.m_maxLength = maxLength;
+  }
+
+  /**
    * Set the timeout (milliseconds) to use for socket comms
-   * 
-   * @param t
-   *          the timeout to use in milliseconds
+   *
+   * @param t the timeout to use in milliseconds
    */
   public void setSocketTimeout( String t ) {
     m_socketTimeout = t;
@@ -144,7 +188,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the timeout (milliseconds) to use for socket comms
-   * 
+   *
    * @return the timeout to use in milliseconds
    */
   public String getSocketTimeout() {
@@ -153,9 +197,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set whether to use pure thrift IO for the <key,value> tuple mode.
-   * 
-   * @param useThrift
-   *          true if thrift IO is to be used
+   *
+   * @param useThrift true if thrift IO is to be used
    */
   public void setUseThriftIO( boolean useThrift ) {
     m_useThriftIO = useThrift;
@@ -163,7 +206,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get whether to use pure thrift IO for the <key,value> tuple mode.
-   * 
+   *
    * @return true if thrift IO is to be used
    */
   public boolean getUseThriftIO() {
@@ -172,9 +215,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set whether to use CQL version 3 is to be used for CQL IO mode
-   * 
-   * @param cql3
-   *          true if CQL version 3 is to be used
+   *
+   * @param cql3 true if CQL version 3 is to be used
    */
   public void setUseCQL3( boolean cql3 ) {
     m_useCQL3 = cql3;
@@ -182,8 +224,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get whether to use CQL version 3 is to be used for CQL IO mode
-   * 
-   * @param return true if CQL version 3 is to be used
+   *
+   * @return true if CQL version 3 is to be used
    */
   public boolean getUseCQL3() {
     return m_useCQL3;
@@ -191,9 +233,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set the cassandra node hostname to connect to
-   * 
-   * @param host
-   *          the host to connect to
+   *
+   * @param host the host to connect to
    */
   public void setCassandraHost( String host ) {
     m_cassandraHost = host;
@@ -201,7 +242,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the name of the cassandra node to connect to
-   * 
+   *
    * @return the name of the cassandra node to connect to
    */
   public String getCassandraHost() {
@@ -210,9 +251,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set the port that cassandra is listening on
-   * 
-   * @param port
-   *          the port that cassandra is listening on
+   *
+   * @param port the port that cassandra is listening on
    */
   public void setCassandraPort( String port ) {
     m_cassandraPort = port;
@@ -220,7 +260,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the port that cassandra is listening on
-   * 
+   *
    * @return the port that cassandra is listening on
    */
   public String getCassandraPort() {
@@ -229,9 +269,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set the keyspace (db) to use
-   * 
-   * @param keyspace
-   *          the keyspace to use
+   *
+   * @param keyspace the keyspace to use
    */
   public void setCassandraKeyspace( String keyspace ) {
     m_cassandraKeyspace = keyspace;
@@ -239,7 +278,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the keyspace (db) to use
-   * 
+   *
    * @return the keyspace (db) to use
    */
   public String getCassandraKeyspace() {
@@ -248,9 +287,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set whether to compress (GZIP) CQL queries when transmitting them to the server
-   * 
-   * @param c
-   *          true if CQL queries are to be compressed
+   *
+   * @param c true if CQL queries are to be compressed
    */
   public void setUseCompression( boolean c ) {
     m_useCompression = c;
@@ -258,7 +296,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get whether CQL queries will be compressed (GZIP) or not
-   * 
+   *
    * @return true if CQL queries will be compressed when sending to the server
    */
   public boolean getUseCompression() {
@@ -267,9 +305,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set the CQL SELECT query to execute.
-   * 
-   * @param query
-   *          the query to execute
+   *
+   * @param query the query to execute
    */
   public void setCQLSelectQuery( String query ) {
     m_cqlSelectQuery = query;
@@ -277,7 +314,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the CQL SELECT query to execute
-   * 
+   *
    * @return the query to execute
    */
   public String getCQLSelectQuery() {
@@ -286,9 +323,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set the username to authenticate with
-   * 
-   * @param un
-   *          the username to authenticate with
+   *
+   * @param un the username to authenticate with
    */
   public void setUsername( String un ) {
     m_username = un;
@@ -296,7 +332,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the username to authenticate with
-   * 
+   *
    * @return the username to authenticate with
    */
   public String getUsername() {
@@ -305,9 +341,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set the password to authenticate with
-   * 
-   * @param pass
-   *          the password to authenticate with
+   *
+   * @param pass the password to authenticate with
    */
   public void setPassword( String pass ) {
     m_password = pass;
@@ -315,7 +350,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the password to authenticate with
-   * 
+   *
    * @return the password to authenticate with
    */
   public String getPassword() {
@@ -324,9 +359,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set whether to output key, column, timestamp tuples as rows rather than standard row format.
-   * 
-   * @param o
-   *          true if tuples are to be output
+   *
+   * @param o true if tuples are to be output
    */
   public void setOutputKeyValueTimestampTuples( boolean o ) {
     m_outputKeyValueTimestampTuples = o;
@@ -334,7 +368,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get whether to output key, column, timestamp tuples as rows rather than standard row format.
-   * 
+   *
    * @return true if tuples are to be output
    */
   public boolean getOutputKeyValueTimestampTuples() {
@@ -343,9 +377,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Set whether the query should be executed for each incoming row
-   * 
-   * @param e
-   *          true if the query should be executed for each incoming row
+   *
+   * @param e true if the query should be executed for each incoming row
    */
   public void setExecuteForEachIncomingRow( boolean e ) {
     m_executeForEachIncomingRow = e;
@@ -353,7 +386,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get whether the query should be executed for each incoming row
-   * 
+   *
    * @return true if the query should be executed for each incoming row
    */
   public boolean getExecuteForEachIncomingRow() {
@@ -365,11 +398,13 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
     StringBuffer retval = new StringBuffer();
 
     if ( !Const.isEmpty( m_cassandraHost ) ) {
-      retval.append( "\n    " ).append( XMLHandler.addTagValue( "cassandra_host", m_cassandraHost ) ); //$NON-NLS-1$ //$NON-NLS-2$
+      retval.append( "\n    " )
+        .append( XMLHandler.addTagValue( "cassandra_host", m_cassandraHost ) ); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     if ( !Const.isEmpty( m_cassandraPort ) ) {
-      retval.append( "\n    " ).append( XMLHandler.addTagValue( "cassandra_port", m_cassandraPort ) ); //$NON-NLS-1$ //$NON-NLS-2$
+      retval.append( "\n    " )
+        .append( XMLHandler.addTagValue( "cassandra_port", m_cassandraPort ) ); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     if ( !Const.isEmpty( m_username ) ) {
@@ -378,32 +413,42 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
     if ( !Const.isEmpty( m_password ) ) {
       retval.append( "\n    " ).append( //$NON-NLS-1$
-          XMLHandler.addTagValue( "password", Encr.encryptPasswordIfNotUsingVariables( m_password ) ) ); //$NON-NLS-1$
+        XMLHandler.addTagValue( "password", Encr.encryptPasswordIfNotUsingVariables( m_password ) ) ); //$NON-NLS-1$
     }
 
     if ( !Const.isEmpty( m_cassandraKeyspace ) ) {
-      retval.append( "\n    " ).append( XMLHandler.addTagValue( "cassandra_keyspace", m_cassandraKeyspace ) ); //$NON-NLS-1$ //$NON-NLS-2$
+      retval.append( "\n    " )
+        .append( XMLHandler.addTagValue( "cassandra_keyspace", m_cassandraKeyspace ) ); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
-    retval.append( "\n    " ).append( XMLHandler.addTagValue( "use_compression", m_useCompression ) ); //$NON-NLS-1$ //$NON-NLS-2$
+    retval.append( "\n    " )
+      .append( XMLHandler.addTagValue( "use_compression", m_useCompression ) ); //$NON-NLS-1$ //$NON-NLS-2$
 
     if ( !Const.isEmpty( m_cqlSelectQuery ) ) {
-      retval.append( "\n    " ).append( XMLHandler.addTagValue( "cql_select_query", m_cqlSelectQuery ) ); //$NON-NLS-1$ //$NON-NLS-2$
+      retval.append( "\n    " )
+        .append( XMLHandler.addTagValue( "cql_select_query", m_cqlSelectQuery ) ); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     retval.append( "\n    " ).append( //$NON-NLS-1$
-        XMLHandler.addTagValue( "output_key_value_timestamp_tuples", m_outputKeyValueTimestampTuples ) ); //$NON-NLS-1$
+      XMLHandler.addTagValue( "output_key_value_timestamp_tuples", m_outputKeyValueTimestampTuples ) ); //$NON-NLS-1$
 
-    retval.append( "\n    " ).append( XMLHandler.addTagValue( "use_thrift_io", m_useThriftIO ) ); //$NON-NLS-1$ //$NON-NLS-2$
+    retval.append( "\n    " )
+      .append( XMLHandler.addTagValue( "use_thrift_io", m_useThriftIO ) ); //$NON-NLS-1$ //$NON-NLS-2$
 
     if ( !Const.isEmpty( m_socketTimeout ) ) {
-      retval.append( "\n    " ).append( XMLHandler.addTagValue( "socket_timeout", m_socketTimeout ) ); //$NON-NLS-1$ //$NON-NLS-2$
+      retval.append( "\n    " )
+        .append( XMLHandler.addTagValue( "socket_timeout", m_socketTimeout ) ); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    if ( !Const.isEmpty( m_maxLength ) ) {
+      retval.append( "\n    " )
+        .append( XMLHandler.addTagValue( "max_length", m_maxLength ) ); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     retval.append( "\n    " ).append( XMLHandler.addTagValue( "use_cql3", m_useCQL3 ) ); //$NON-NLS-1$ //$NON-NLS-2$
 
     retval.append( "    " ).append( //$NON-NLS-1$
-        XMLHandler.addTagValue( "execute_for_each_row", m_executeForEachIncomingRow ) ); //$NON-NLS-1$
+      XMLHandler.addTagValue( "execute_for_each_row", m_executeForEachIncomingRow ) ); //$NON-NLS-1$
 
     return retval.toString();
   }
@@ -420,7 +465,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
     }
     m_cassandraKeyspace = XMLHandler.getTagValue( stepnode, "cassandra_keyspace" ); //$NON-NLS-1$
     m_cqlSelectQuery = XMLHandler.getTagValue( stepnode, "cql_select_query" ); //$NON-NLS-1$
-    m_useCompression = XMLHandler.getTagValue( stepnode, "use_compression" ).equalsIgnoreCase( "Y" ); //$NON-NLS-1$ //$NON-NLS-2$
+    m_useCompression =
+      XMLHandler.getTagValue( stepnode, "use_compression" ).equalsIgnoreCase( "Y" ); //$NON-NLS-1$ //$NON-NLS-2$
 
     String kV = XMLHandler.getTagValue( stepnode, "output_key_value_timestamp_tuples" ); //$NON-NLS-1$
 
@@ -444,6 +490,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
     }
 
     m_socketTimeout = XMLHandler.getTagValue( stepnode, "socket_timeout" ); //$NON-NLS-1$
+    m_maxLength = XMLHandler.getTagValue( stepnode, "max_length" ); //$NON-NLS-1$
   }
 
   @Override
@@ -460,13 +507,15 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
     m_cqlSelectQuery = rep.getStepAttributeString( id_step, 0, "cql_select_query" ); //$NON-NLS-1$
     m_useCompression = rep.getStepAttributeBoolean( id_step, 0, "use_compression" ); //$NON-NLS-1$
 
-    m_outputKeyValueTimestampTuples = rep.getStepAttributeBoolean( id_step, 0, "output_key_value_timestamp_tuples" ); //$NON-NLS-1$
+    m_outputKeyValueTimestampTuples =
+      rep.getStepAttributeBoolean( id_step, 0, "output_key_value_timestamp_tuples" ); //$NON-NLS-1$
     m_useThriftIO = rep.getStepAttributeBoolean( id_step, 0, "use_thrift_io" ); //$NON-NLS-1$
     m_useCQL3 = rep.getStepAttributeBoolean( id_step, 0, "use_cql3" ); //$NON-NLS-1$
 
     m_executeForEachIncomingRow = rep.getStepAttributeBoolean( id_step, "execute_for_each_row" ); //$NON-NLS-1$        
 
     m_socketTimeout = rep.getStepAttributeString( id_step, 0, "socket_timeout" ); //$NON-NLS-1$
+    m_maxLength = rep.getStepAttributeString( id_step, 0, "max_length" ); //$NON-NLS-1$
   }
 
   @Override
@@ -485,7 +534,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
     if ( !Const.isEmpty( m_password ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "password", Encr //$NON-NLS-1$
-          .encryptPasswordIfNotUsingVariables( m_password ) );
+        .encryptPasswordIfNotUsingVariables( m_password ) );
     }
 
     if ( !Const.isEmpty( m_cassandraKeyspace ) ) {
@@ -499,30 +548,34 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
     }
 
     rep.saveStepAttribute( id_transformation, id_step, 0, "output_key_value_timestamp_tuples", //$NON-NLS-1$
-        m_outputKeyValueTimestampTuples );
+      m_outputKeyValueTimestampTuples );
 
     rep.saveStepAttribute( id_transformation, id_step, 0, "use_thrift_io", m_useThriftIO ); //$NON-NLS-1$
 
     rep.saveStepAttribute( id_transformation, id_step, 0, "use_cql3", m_useCQL3 ); //$NON-NLS-1$
 
     rep.saveStepAttribute( id_transformation, id_step, 0, "execute_for_each_row", //$NON-NLS-1$
-        m_executeForEachIncomingRow );
+      m_executeForEachIncomingRow );
 
     if ( !Const.isEmpty( m_socketTimeout ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "socket_timeout", m_socketTimeout ); //$NON-NLS-1$
+    }
+
+    if ( !Const.isEmpty( m_maxLength ) ) {
+      rep.saveStepAttribute( id_transformation, id_step, 0, "max_length", m_maxLength ); //$NON-NLS-1$
     }
   }
 
   @Override
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta, RowMetaInterface prev,
-      String[] input, String[] output, RowMetaInterface info ) {
+                     String[] input, String[] output, RowMetaInterface info ) {
     // TODO Auto-generated method stub
 
   }
 
   @Override
   public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
-      TransMeta transMeta, Trans trans ) {
+                                TransMeta transMeta, Trans trans ) {
 
     return new CassandraInput( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
@@ -539,11 +592,12 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
     m_cqlSelectQuery = "SELECT <fields> FROM <column family> WHERE <condition>;"; //$NON-NLS-1$
     m_useCompression = false;
     m_socketTimeout = ""; //$NON-NLS-1$
+    m_maxLength = ""; //$NON-NLS-1$
   }
 
   @Override
   public void getFields( RowMetaInterface rowMeta, String origin, RowMetaInterface[] info, StepMeta nextStep,
-      VariableSpace space ) throws KettleStepException {
+                         VariableSpace space ) throws KettleStepException {
 
     m_specificCols = null;
     m_rowLimit = -1;
@@ -574,12 +628,14 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
       // is there a LIMIT clause?
       if ( subQ.toLowerCase().indexOf( "limit" ) > 0 ) { //$NON-NLS-1$
-        String limitS = subQ.toLowerCase().substring( subQ.toLowerCase().indexOf( "limit" ) + 5, subQ.length() ).trim(); //$NON-NLS-1$
+        String limitS =
+          subQ.toLowerCase().substring( subQ.toLowerCase().indexOf( "limit" ) + 5, subQ.length() ).trim(); //$NON-NLS-1$
         limitS = limitS.replaceAll( ";", "" ); //$NON-NLS-1$ //$NON-NLS-2$
         try {
           m_rowLimit = Integer.parseInt( limitS );
         } catch ( NumberFormatException ex ) {
-          logError( BaseMessages.getString( PKG, "CassandraInput.Error.UnableToParseLimitClause", m_cqlSelectQuery ) ); //$NON-NLS-1$
+          logError( BaseMessages
+            .getString( PKG, "CassandraInput.Error.UnableToParseLimitClause", m_cqlSelectQuery ) ); //$NON-NLS-1$
           m_rowLimit = 10000;
         }
       }
@@ -595,7 +651,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
       String tempS = subQ.toLowerCase();
       int offset = fromIndex;
       while ( fromIndex > 0 && tempS.charAt( fromIndex - 1 ) != ' ' && ( fromIndex + 4 < tempS.length() )
-          && tempS.charAt( fromIndex + 4 ) != ' ' ) {
+        && tempS.charAt( fromIndex + 4 ) != ' ' ) {
         tempS = tempS.substring( fromIndex + 4, tempS.length() );
         fromIndex = tempS.indexOf( "from" ); //$NON-NLS-1$
         offset += ( 4 + fromIndex );
@@ -629,7 +685,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
         try {
           m_colLimit = Integer.parseInt( firstS );
         } catch ( NumberFormatException ex ) {
-          logError( BaseMessages.getString( PKG, "CassandraInput.Error.UnableToParseFirstClause", m_cqlSelectQuery ) ); //$NON-NLS-1$
+          logError( BaseMessages
+            .getString( PKG, "CassandraInput.Error.UnableToParseFirstClause", m_cqlSelectQuery ) ); //$NON-NLS-1$
           return;
         }
       } else {
@@ -671,8 +728,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
         }
 
         conn =
-            CassandraUtils.getCassandraConnection( hostS, Integer.parseInt( portS ), userS, passS,
-                ConnectionFactory.Driver.LEGACY_THRIFT, opts );
+          CassandraUtils.getCassandraConnection( hostS, Integer.parseInt( portS ), userS, passS,
+            ConnectionFactory.Driver.LEGACY_THRIFT, opts );
 
         /*
          * conn = CassandraInputData.getCassandraConnection(hostS, Integer.parseInt(portS), userS, passS);
@@ -752,14 +809,16 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
               // this one isn't known about in about in the schema - we can
               // output it
               // as long as its values satisfy the default validator...
-              logBasic( BaseMessages.getString( PKG, "CassandraInput.Info.DefaultColumnValidator", col ) ); //$NON-NLS-1$
+              logBasic(
+                BaseMessages.getString( PKG, "CassandraInput.Info.DefaultColumnValidator", col ) ); //$NON-NLS-1$
             }
             ValueMetaInterface vm = colMeta.getValueMetaForColumn( col );
             rowMeta.addValueMeta( vm );
           }
         }
       } catch ( Exception ex ) {
-        logBasic( BaseMessages.getString( PKG, "CassandraInput.Info.UnableToRetrieveColumnMetaData", colFamName ), ex ); //$NON-NLS-1$
+        logBasic( BaseMessages.getString( PKG, "CassandraInput.Info.UnableToRetrieveColumnMetaData", colFamName ),
+          ex ); //$NON-NLS-1$
         return;
       } finally {
         if ( conn != null ) {
@@ -788,15 +847,11 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
 
   /**
    * Get the UI for this step.
-   * 
-   * @param shell
-   *          a <code>Shell</code> value
-   * @param meta
-   *          a <code>StepMetaInterface</code> value
-   * @param transMeta
-   *          a <code>TransMeta</code> value
-   * @param name
-   *          a <code>String</code> value
+   *
+   * @param shell     a <code>Shell</code> value
+   * @param meta      a <code>StepMetaInterface</code> value
+   * @param transMeta a <code>TransMeta</code> value
+   * @param name      a <code>String</code> value
    * @return a <code>StepDialogInterface</code> value
    */
   public StepDialogInterface getDialog( Shell shell, StepMetaInterface meta, TransMeta transMeta, String name ) {

--- a/src/org/pentaho/di/trans/steps/cassandrainput/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/messages/messages_en_US.properties
@@ -4,6 +4,7 @@ CassandraInputDialog.StepName.Label=Step name
 CassandraInputDialog.Hostname.Label=Cassandra host
 CassandraInputDialog.Port.Label=Cassandra port
 CassandraInputDialog.Timeout.Label=Socket timeout
+CassandraInputDialog.TransportMaxLength.Label=Transport max length
 CassandraInputDialog.Keyspace.Label=Keyspace
 CassandraInputDialog.OutputTuples.Label=Output <key, column, timestamp> tuples
 CassandraInputDialog.OutputTuples.TipText=CQL 3 automatically outputs dynamic column families in tuple mode (i.e. a wide row is transposed to multiple CQL 3 rows)

--- a/test-src/org/pentaho/cassandra/legacy/CassandraConnectionTest.java
+++ b/test-src/org/pentaho/cassandra/legacy/CassandraConnectionTest.java
@@ -1,0 +1,44 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.cassandra.legacy;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 7/7/14 Time: 5:09 PM
+ */
+public class CassandraConnectionTest {
+
+  @Test
+  public void testSetAdditionalOptions() throws Exception {
+    CassandraConnection cassandraConnection  = new CassandraConnection(  );
+    Map<String, String> opts = new HashMap<String, String>(  );
+    opts.put( "maxLength", "1000" );
+    cassandraConnection.setAdditionalOptions( opts );
+    assertEquals( 1000, cassandraConnection.m_maxlength );
+  }
+}


### PR DESCRIPTION
According to the fix: if you get exception about "timeout" - just increase timeout value. After could be gotten exception related to that frame size is larger than some default value - in this case specify value you needed or more in transport max length field.
- Added new configurable property ConnectionOptions.MAX_LENGTH  - if empty  would use default client value.
