### PR TITLE
CQL3 fails with an exception connecting to Cassandra 2.1.7 for input/output steps.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -2,17 +2,16 @@ impl.title=Pentaho Cassandra Plugin
 impl.productID=pentaho-cassandra-plugin
 ivy.artifact.id=pentaho-cassandra-plugin
 ivy.artifact.group=pentaho
-project.revision=TRUNK-SNAPSHOT
+project.revision=5.4.0.0-128
 
 junit.maxmemory=500M
 
-dependency.kettle.revision=TRUNK-SNAPSHOT
-dependency.kettle5-log4j.revision=TRUNK-SNAPSHOT
-dependency.pentaho-metastore.revision=TRUNK-SNAPSHOT
+dependency.kettle.revision=5.4.0.0-128
+dependency.kettle5-log4j.revision=5.4.0.0-128
+dependency.pentaho-metastore.revision=5.4.0.0-128
 
 dependency.libthrift.revision=0.9.1
 dependency.apache-cassandra.revision=2.0.7
 dependency.apache-cassandra-thrift.revision=2.0.7
 dependency.snakeyaml.revision=1.11
-dependency.pentaho-metastore.revision=TRUNK-SNAPSHOT
 dependency.guava.revision=15.0


### PR DESCRIPTION
 Cassandra 2.1.7 has deprecated the following column metadata properties
populate_io_cache_on_flush and replicate_on_write, and will throw an exception when these are added to the select clause.


