### PR TITLE
[PDI-13137]: Cassandra Input: Functions in Select Clause

### DIFF
--- a/src/org/pentaho/cassandra/cql/CQLFunctions.java
+++ b/src/org/pentaho/cassandra/cql/CQLFunctions.java
@@ -1,0 +1,66 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.cassandra.cql;
+
+/**
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+public enum CQLFunctions {
+  TOKEN( "org.apache.cassandra.db.marshal.LongType" ), COUNT( "org.apache.cassandra.db.marshal.LongType" ), WRITETIME(
+      "org.apache.cassandra.db.marshal.LongType" ), TTL( "org.apache.cassandra.db.marshal.Int32Type" ), DATEOF(
+      "org.apache.cassandra.db.marshal.TimestampType" ), UNIXTIMESTAMPOF( "org.apache.cassandra.db.marshal.LongType" );
+
+  private final String validator;
+
+  private CQLFunctions( String validator ) {
+    this.validator = validator;
+  }
+
+  /**Returns the Cassandra validator class for the function.
+   * @return the Cassandra validator class for the function.
+   */
+  public String getValidator() {
+    return validator;
+  }
+
+  /** Returns CQLFunction by the string representation of it.
+   * @param input the string representation of CQLFunction
+   * @return the CQLFunction if the input string contains this one, otherwise null.
+   */
+  public static CQLFunctions getFromString( String input ) {
+    if ( input != null ) {
+      input = input.trim().toUpperCase();
+      for ( CQLFunctions fs : CQLFunctions.values() ) {
+        if ( isFunction( fs, input ) ) {
+          return fs;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static boolean isFunction( CQLFunctions fs, String input ) {
+    return input.equals( fs.name() );
+  }
+
+}

--- a/src/org/pentaho/cassandra/cql/CQLUtils.java
+++ b/src/org/pentaho/cassandra/cql/CQLUtils.java
@@ -1,0 +1,271 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.cassandra.cql;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.pentaho.di.core.Const;
+
+/**
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+/**
+ * Utilities for CQL processing.
+ *
+ */
+public class CQLUtils {
+
+  private static final Pattern WHITESPACE_PATTERN = Pattern.compile( "(\\s){2,}" );
+  private static final Pattern WHITESPACE_IN_FUNCTION_OPEN_BRACKET_PATTERN = Pattern.compile( "(\\s)*(\\()(\\s)*" );
+  private static final Pattern WHITESPACE_IN_FUNCTION_CLOSE_BRACKET_PATTERN = Pattern.compile( "(\\s)*(\\))" );
+  private static final Pattern UNNECESSARY_WHITESPACE_BEFORE_COMMA_PATTERN = Pattern.compile( "(\\s)+(,)" );
+  private static final Pattern ADD_WHITESPACE_AFTER_COMMA_PATTERN = Pattern.compile( "(,)(?=[\\da-zA-Z])" );
+  private static final Pattern DOUBLE_QUOTES_PATTERN = Pattern.compile( "\"" );
+  private static final Pattern QUOTE_PATTERN = Pattern.compile( "\'" );
+
+  private static final String DISTING = "disting";
+  private static final String FIRST = "first";
+  private static final String OPEN_BRACKET = "(";
+  private static final String CLOSE_BRACKET = ")";
+  private static final String ALIAS_INDICATOR = " AS ";
+  private static final String COMMA = ",";
+  private static final String SELECT = "select";
+  private static final String FROM = "from";
+  private static final String SPACE = " ";
+
+  private enum SpecificNames {
+
+    COUNT( "count(*)", "count(1)" );
+
+    List<String> variants;
+
+    private SpecificNames( String... variants ) {
+      this.variants = Arrays.asList( variants );
+    }
+
+    private List<String> getVariants() {
+      return variants;
+    }
+
+    private static final Map<String, String> SPECIFIC_NAMES = new HashMap<>();
+    static {
+      for ( SpecificNames sName : SpecificNames.values() ) {
+        for ( String variants : sName.getVariants() ) {
+          SPECIFIC_NAMES.put( variants.toUpperCase(), sName.name() );
+        }
+      }
+    }
+
+    private static String getName( String value ) {
+      return SPECIFIC_NAMES.get( value.toUpperCase() );
+    }
+  };
+
+  private static ArrayList<Selector> getSelectors( String selectExpression, boolean isCql3 ) {
+    ArrayList<Selector> sList = new ArrayList<Selector>();
+    selectExpression = clean( selectExpression );
+    while ( selectExpression.length() > 0 ) {
+      int possibleEnd = selectExpression.indexOf( COMMA );
+      String possibleSelectorElement =
+          ( possibleEnd != -1 ) ? selectExpression.substring( 0, possibleEnd ) : selectExpression;
+      selectExpression =
+          ( possibleEnd != -1 ) ? selectExpression.substring( possibleEnd + 1, selectExpression.length() ).trim() : "";
+
+      Selector realSelectorElement = buildSelector( possibleSelectorElement, isCql3 );
+
+      if ( !isPartOfFunction( possibleSelectorElement ) || isFunction( possibleSelectorElement ) ) {
+        realSelectorElement = buildSelector( possibleSelectorElement, isCql3 );
+      } else {
+        // The part of the function, we need one more part
+        StringBuffer sb = new StringBuffer();
+        sb.append( possibleSelectorElement ).append( COMMA ).append( SPACE );
+        int indexFunctionEnd = selectExpression.indexOf( CLOSE_BRACKET );
+        possibleEnd = selectExpression.indexOf( COMMA, indexFunctionEnd );
+        possibleSelectorElement =
+            ( possibleEnd != -1 ) ? selectExpression.substring( 0, possibleEnd ) : selectExpression;
+        sb.append( possibleSelectorElement );
+        possibleSelectorElement = sb.toString();
+        selectExpression =
+            ( possibleEnd != -1 ) ? selectExpression.substring( possibleEnd + 1, selectExpression.length() ).trim()
+                : "";
+        realSelectorElement = buildSelector( possibleSelectorElement, isCql3 );
+      }
+      sList.add( realSelectorElement );
+    }
+    return sList;
+  }
+
+  /**Extract select expression from the select clause. Assumes that any kettle variables have been
+   * already substituted in the query.
+   * @param cqlExpresssion the select clause
+   * @return the select expression. Null if select clause is empty or null.
+   */
+  public static String getSelectExpression( String cqlExpresssion ) {
+    String selectExpression = null;
+    if ( !Const.isEmpty( cqlExpresssion ) ) {
+      cqlExpresssion = clean( cqlExpresssion );
+      int end = cqlExpresssion.toLowerCase().indexOf( FROM );
+      int start = cqlExpresssion.toLowerCase().indexOf( SELECT ) + SELECT.length();
+      if ( start > -1 && end > -1 ) {
+        selectExpression = cqlExpresssion.substring( start, end );
+        int firstInd = selectExpression.toLowerCase().indexOf( FIRST );
+        if ( firstInd > -1 ) {
+          selectExpression = selectExpression.substring( firstInd + FIRST.length() );
+        }
+        int distInd = selectExpression.toLowerCase().indexOf( DISTING );
+        if ( distInd > -1 ) {
+          selectExpression = selectExpression.substring( firstInd + DISTING.length() ).trim();
+        }
+      }
+    }
+    return selectExpression;
+  }
+
+  /**Returns the array of selectors
+   * @param selectExpression the CQL select expression
+   * @param isCql3 the indicator of CQL3 version used
+   * @return the array of selectors
+   */
+  public static Selector[] getColumnsInSelect( String selectExpression, boolean isCql3 ) {
+    if ( !Const.isEmpty( selectExpression ) ) {
+      ArrayList<Selector> selectors = getSelectors( selectExpression.trim(), isCql3 );
+      return selectors.toArray( new Selector[selectors.size()] );
+    }
+    return null;
+  }
+
+  static Selector buildSelector( String selector, boolean isCql3 ) {
+    String columnName = getColumnName( selector, isCql3 );
+    return new Selector( getGeneralVariantForSpecificNames( columnName ), getAlias( selector, isCql3 ),
+        getFunction( selector ) );
+  }
+
+  private static String getFunction( String selector ) {
+    String f = null;
+    if ( isFunction( selector ) ) {
+      f = selector.substring( 0, selector.indexOf( OPEN_BRACKET ) ).trim().toLowerCase();
+    }
+    return f;
+  }
+
+  private static boolean isPartOfFunction( String element ) {
+    // there is at least one left or right bracket
+    return element.indexOf( OPEN_BRACKET ) > 0 || element.indexOf( CLOSE_BRACKET ) > 0;
+  }
+
+  private static boolean isFunction( String element ) {
+    // there are both brackets
+    return element.indexOf( OPEN_BRACKET ) > 0 && element.indexOf( CLOSE_BRACKET ) > 0;
+  }
+
+  private static final String getColumnName( String element, boolean isCql3 ) {
+    String name = element.trim();
+    int idx = element.toUpperCase().indexOf( ALIAS_INDICATOR );
+    if ( idx > -1 ) {
+      name = name.substring( 0, idx ).trim();
+    }
+    if ( !isFunction( element ) ) {
+      getNormalizedForCql3Name( name, isCql3 );
+    }
+    name = cleanQuotes( name );
+    return name;
+  }
+
+  private static String getAlias( String element, boolean isCql3 ) {
+    String alias = null;
+    int idx = element.toUpperCase().indexOf( ALIAS_INDICATOR );
+    if ( idx > -1 ) {
+      alias = getNormalizedForCql3Name( element.substring( idx + ALIAS_INDICATOR.length() ), isCql3 );
+      alias = cleanQuotes( alias );
+    }
+    return alias;
+  }
+
+  static String cleanUnnecessaryWhitespaces( String input ) {
+    String cleaned = null;
+    if ( input != null ) {
+      cleaned = WHITESPACE_PATTERN.matcher( input.trim() ).replaceAll( SPACE );
+      cleaned = WHITESPACE_IN_FUNCTION_OPEN_BRACKET_PATTERN.matcher( cleaned.trim() ).replaceAll( "$2" );
+      cleaned = WHITESPACE_IN_FUNCTION_CLOSE_BRACKET_PATTERN.matcher( cleaned.trim() ).replaceAll( "$2" );
+      cleaned = UNNECESSARY_WHITESPACE_BEFORE_COMMA_PATTERN.matcher( cleaned.trim() ).replaceAll( "$2" );
+    }
+    return cleaned;
+  }
+
+  static String addWhitespaceAfterComa( String input ) {
+    String cleaned = null;
+    if ( input != null ) {
+      cleaned = ADD_WHITESPACE_AFTER_COMMA_PATTERN.matcher( input.trim() ).replaceAll( "$1 " );
+    }
+    return cleaned;
+  }
+
+  /**Clean input from all unnecessary whitespaces: double and etc., before comma, inside functions and etc.
+   * Add whitespace after comma if it is absent.
+   * @param input the input string
+   * @return cleaned string
+   */
+  public static String clean( String input ) {
+    String cleaned = null;
+    if ( input != null ) {
+      cleaned = cleanUnnecessaryWhitespaces( input );
+      cleaned = addWhitespaceAfterComa( cleaned );
+    }
+    return cleaned;
+  }
+
+  static String cleanQuotes( String input ) {
+    String cleaned = null;
+    if ( input != null ) {
+      cleaned = DOUBLE_QUOTES_PATTERN.matcher( input ).replaceAll( "" );
+      cleaned = QUOTE_PATTERN.matcher( cleaned ).replaceAll( "" );
+    }
+    return cleaned;
+  }
+
+  static boolean isQuoted( String input ) {
+    return DOUBLE_QUOTES_PATTERN.matcher( input ).find() || QUOTE_PATTERN.matcher( input ).find();
+  }
+
+  static String getGeneralVariantForSpecificNames( String sName ) {
+    String gName = null;
+    if ( sName != null ) {
+      String name = SpecificNames.getName( sName );
+      gName = name != null ? name : sName;
+    }
+    return gName;
+  }
+
+  private static String getNormalizedForCql3Name( String input, boolean isCql3 ) {
+    String normalizedName = input;
+    if ( isCql3 && !isQuoted( input ) ) {
+      normalizedName = input.toLowerCase();
+    }
+    return normalizedName;
+  }
+}

--- a/src/org/pentaho/cassandra/cql/Partitioners.java
+++ b/src/org/pentaho/cassandra/cql/Partitioners.java
@@ -1,0 +1,73 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.cassandra.cql;
+
+/**
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+public enum Partitioners {
+  MURMUR3( "Murmur3Partitioner", "org.apache.cassandra.db.marshal.LongType" ), RANDOM( "RandomPartitioner",
+      "org.apache.cassandra.db.marshal.IntegerType" ), BYTEORDERED( "ByteOrderedPartitioner",
+      "org.apache.cassandra.db.marshal.BytesType" );
+
+  private final String name;
+
+  private final String type;
+
+  /**
+   * @param name
+   * @param type
+   */
+  private Partitioners( String name, String type ) {
+    this.name = name;
+    this.type = type;
+  }
+
+  /**
+   * @return the name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the type
+   */
+  public String getType() {
+    return type;
+  }
+
+  public static Partitioners getFromString( String string ) {
+    if ( string == null ) {
+      return MURMUR3;
+    }
+
+    for ( Partitioners prs : Partitioners.values() ) {
+      if ( string.endsWith( prs.getName() ) ) {
+        return prs;
+      }
+    }
+    return MURMUR3;
+  }
+
+}

--- a/src/org/pentaho/cassandra/cql/Selector.java
+++ b/src/org/pentaho/cassandra/cql/Selector.java
@@ -1,0 +1,109 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.cassandra.cql;
+
+/**
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+/**
+ * A representation of a selector in a selection list of a select clause. 
+ *
+ */
+public class Selector {
+
+  private String columnName;
+
+  private String alias;
+
+  private CQLFunctions function;
+
+  private boolean isFunction;
+
+  /**
+   * @param columnName
+   */
+  public Selector( String columnName ) {
+    this( columnName, null );
+  }
+
+  /**
+   * @param columnName
+   * @param alias
+   */
+  public Selector( String columnName, String alias ) {
+    this( columnName, alias, null );
+  }
+
+  /**
+   * @param columnName
+   * @param alias
+   * @param function
+   */
+  public Selector( String columnName, String alias, String function ) {
+    super();
+    this.columnName = columnName;
+    this.alias = alias;
+    this.function = CQLFunctions.getFromString( function );
+    this.isFunction = this.function != null;
+  }
+
+  /**
+   * @return the alias
+   */
+  public String getAlias() {
+    return alias;
+  }
+
+  /**
+   * @return the columnName
+   */
+  public String getColumnName() {
+    return columnName;
+  }
+
+  /**
+   * @return the function
+   */
+  public CQLFunctions getFunction() {
+    return function;
+  }
+
+  /**
+   * @return the isFunction
+   */
+  public boolean isFunction() {
+    return isFunction;
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "Selector [columnName=" + columnName + ", alias=" + alias + ", function=" + function + ", isFunction="
+        + isFunction + "]";
+  }
+
+}

--- a/src/org/pentaho/cassandra/spi/ColumnFamilyMetaData.java
+++ b/src/org/pentaho/cassandra/spi/ColumnFamilyMetaData.java
@@ -24,6 +24,7 @@ package org.pentaho.cassandra.spi;
 
 import java.util.List;
 
+import org.pentaho.cassandra.cql.Selector;
 import org.pentaho.di.core.row.ValueMetaInterface;
 
 /**
@@ -119,4 +120,13 @@ public interface ColumnFamilyMetaData {
    *         column family
    */
   List<ValueMetaInterface> getValueMetasForSchema();
+
+  /**
+   * Return the appropriate Kettle type for the selector depending on id this is column or function. If the column is
+   * not explicitly named in the column family schema or the function is incorrect named then the Kettle type
+   * equivalent to the default validation class should be returned.
+   * @param selector the selector that corresponds either to Cassandra column name or Cassandra function to get the Kettle type
+   * @return the Kettle type for the selector
+   */
+  ValueMetaInterface getValueMeta( Selector selector );
 }

--- a/test-src/org/pentaho/cassandra/cql/CQLUtilsTest.java
+++ b/test-src/org/pentaho/cassandra/cql/CQLUtilsTest.java
@@ -1,0 +1,35 @@
+/*!
+ * Copyright 2014 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.cassandra.cql;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class CQLUtilsTest {
+
+  @Test
+  public void testDeleteQoutes() {
+    String cqlExpresssion = "one_more as \"\"ALIAS\", field(a, b) as '\"aaaaa'";
+    String expected = "one_more as ALIAS, field(a, b) as aaaaa";
+
+    String result = CQLUtils.cleanQuotes( cqlExpresssion );
+    assertEquals( expected, result );
+  }
+
+}


### PR DESCRIPTION
This is initial implementation.
What has been done:
1)Added support for alias in select clause (for CQL3);
2)Added support for the cassandra functions (see http://docs.datastax.com/en/cql/3.1/cql/cql_reference/cql_function_r.html) that could be used in Select clause:
ttl(), writetime(), token(), dateOf(),unixTimestampOf(), count(*|1).
3)Started covering changes with unit tests.