### PR TITLE
 PDI-14838 - As a modern developer I want to be able to assemble pentaho-cassandra-plugin using java 8 jdk

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -7,6 +7,7 @@ project.revision=6.1-SNAPSHOT
 junit.maxmemory=500M
 
 dependency.kettle.revision=6.1-SNAPSHOT
+dependency.pentaho-xul.revision=6.1-SNAPSHOT
 dependency.kettle5-log4j.revision=6.1-SNAPSHOT
 dependency.pentaho-metastore.revision=6.1-SNAPSHOT
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -25,6 +25,7 @@
       changing="true" />
     <dependency org="pentaho-kettle" name="kettle-ui-swt" rev="${dependency.kettle.revision}" transitive="false" conf="default->default"
       changing="true" />
+    <dependency org="pentaho" name="pentaho-xul-core" rev="${dependency.pentaho-xul.revision}" changing="true" />
 
     <dependency org="pentaho"             name="metastore"           rev="${dependency.pentaho-metastore.revision}"   changing="true" />
 


### PR DESCRIPTION
Since java 8 brings 'With Java 8, when using a class, the interfaces it
 implements must be on the compile classpath as well. With Java 7, it was
 enough that the interface was on the classpath while compiling the used
 class.' penatho-cassandra-plugin require direct dependecy on
 pentaho-xul-core to be able to compile agaings java 8.