### PR TITLE
[PPP-3892] - Use of vulnerable component org.codehaus.jackson : jacks…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -147,7 +147,14 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 		</dependency>
-
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+        </dependency>
 		<!-- ######################### TEST ######################### -->
 		<dependency>
 			<groupId>pentaho-kettle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,24 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+                <version>${jackson.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>${jackson.version}</version>
+                <scope>compile</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
 			<!-- ######################### RUNTIME ######################### -->
 			<!-- runtime dependencies go here -->


### PR DESCRIPTION
…on-mapper-asl : 1.5.2, org.codehaus.jackson : jackson-mapper-asl : 1.9.12, org.codehaus.jackson : jackson-mapper-asl 1.9.13,org.codehaus.jackson:jackson-mapper-asl-1.8.8.jar CVE-2017-7525

 - add jackson back to compile dependencies since cassandra-all jar needed it.