### PR TITLE
[PPP-3892] - Use of vulnerable component org.codehaus.jackson : jacks…

### DIFF
--- a/assemblies/plugin/src/assembly/assembly.xml
+++ b/assemblies/plugin/src/assembly/assembly.xml
@@ -40,6 +40,8 @@
 				<include>org.yaml:snakeyaml</include>
 				<include>com.clearspring.analytics:stream</include>
 				<include>net.sf.supercsv:super-csv</include>
+				<include>org.codehaus.jackson:jackson-core-asl</include>
+				<include>org.codehaus.jackson:jackson-mapper-asl</include>
 			</includes>
 		</dependencySet>
 	</dependencySets>


### PR DESCRIPTION
…on-mapper-asl : 1.5.2, org.codehaus.jackson : jackson-mapper-asl : 1.9.12, org.codehaus.jackson : jackson-mapper-asl 1.9.13,org.codehaus.jackson:jackson-mapper-asl-1.8.8.jar CVE-2017-7525

 - added jackson-mapper-asl and jackson-mapper-core to lib directory

@pamval, @mbatchelor, could you please take a look?