### PR TITLE
Bump netty version to 4.0.56.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <commons-xul.version>9.1.0.0-SNAPSHOT</commons-xul.version>
     <guava.version>17.0</guava.version>
     <snakeyaml.version>1.11</snakeyaml.version>
-    <netty.version>4.0.44.Final</netty.version>
+    <netty.version>4.0.56.Final</netty.version>
     <clearspring-stream.version>2.8.0</clearspring-stream.version>
     <sigar.version>1.6.4</sigar.version>
     <dropwizard-metrics.version>3.1.0</dropwizard-metrics.version>


### PR DESCRIPTION
Bumping netty version resolves problem with  many cassandra inputs: https://stackoverflow.com/questions/55103689/pentaho-problem-with-cassandra-datastax-driver/60499388#60499388